### PR TITLE
Fix include block in pyproject.toml to include Python source directories

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ authors = [
 ]
 license = "CC0-1.0 license"
 readme = "README.md"
-include = ["README.md", "src/mixs/schema", "project"]
+include = ["README.md", "src/mixs/schema", "project", "src/mixs", "src/scripts"]
 
 [tool.poetry.dependencies]
 python = "^3.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ authors = [
 ]
 license = "CC0-1.0 license"
 readme = "README.md"
-include = ["README.md", "src/mixs/schema", "project", "src/mixs", "src/scripts"]
+include = ["README.md", "project", "src/mixs", "src/scripts"]
 
 [tool.poetry.dependencies]
 python = "^3.9"


### PR DESCRIPTION
Add src/mixs and src/scripts directories to the package include list to ensure Python modules and scripts are properly included in the distribution.

🤖 Generated with [Claude Code](https://claude.ai/code)